### PR TITLE
fixed grep links to say grep instead of awk

### DIFF
--- a/resources/online-tutorials/index.html
+++ b/resources/online-tutorials/index.html
@@ -2589,8 +2589,8 @@
 <h3 id="grep"><code>grep</code></h3>
 <p>Grep is tool for searching command line output or files for a certain string (phrase) or regular expression.</p>
 <ul>
-<li><a href="https://www.freecodecamp.org/news/grep-command-tutorial-how-to-search-for-a-file-in-linux-and-unix/">Introduction to <code>awk</code> and examples of common usage</a></li>
-<li><a href="https://www.geeksforgeeks.org/grep-command-in-unixlinux/">In-depth guide to <code>awk</code> and more advanced usage</a></li>
+<li><a href="https://www.freecodecamp.org/news/grep-command-tutorial-how-to-search-for-a-file-in-linux-and-unix/">Introduction to <code>grep</code> and examples of common usage</a></li>
+<li><a href="https://www.geeksforgeeks.org/grep-command-in-unixlinux/">In-depth guide to <code>grep</code> and more advanced usage</a></li>
 </ul>
 <h3 id="sed"><code>sed</code></h3>
 <p><code>sed</code> (Stream EDitor) is a tool for making substitutions in a text file. For example, it can be useful for cleaning (e.g. replace NAN with 0) or reformatting data files. The syntax <code>sed</code> uses for substitutions is common in Linux (for example, the same syntax is used in the VIM text editor).</p>


### PR DESCRIPTION
Fixed the grep tutorial links to say "grep" instead of "awk"